### PR TITLE
Refactor main msak.js module

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,9 @@
 {
     presets: [
         [
-        '@babel/preset-env',
+            '@babel/preset-env',
             {
-          modules: false
+                modules: false,
             }
         ]
     ]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
   },
   "parser": "@babel/eslint-parser",
   "parserOptions": {
-    "ecmaVersion": 2018,
+    "ecmaVersion": "latest",
     "sourceType": "module"
   },
   "extends": "eslint:recommended",

--- a/index.html
+++ b/index.html
@@ -6,18 +6,11 @@
     <title>MSAK client</title>
 </head>
 <body>
-    <script src="dist/bundle.js" type="text/javascript"></script>
+    <script src="dist/msak.js" type="text/javascript"></script>
     <script>
-    msak.test({
-        streams: 4,
-    }, {
-        serverChosen: function(server) {
-            console.log("Server chosen:", server);
-        },
-        downloadMeasurement: function(data) {
-            console.log(data);
-        },
-    });
+        m = new msak.Client("msakjs-example", "0.1.0");
+        m.debug = true;
+        m.start();
     </script>
 </body>
 </html>

--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -1,0 +1,17 @@
+// cb creates a default-empty callback function, allowing library users to
+// only need to specify callback functions for the events they care about.
+export const cb = function (name, callbacks, defaultFn) {
+    if (typeof (callbacks) !== 'undefined' && name in callbacks) {
+        return callbacks[name];
+    } else if (typeof defaultFn !== 'undefined') {
+        return defaultFn;
+    } else {
+        // If no default function is provided, use the empty function.
+        return function () { };
+    }
+};
+
+// The default response to an error is to throw an exception.
+export const defaultErrCallback = function (err) {
+    throw new Error(err);
+};

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,0 +1,13 @@
+export const LIBRARY_NAME = 'msak-js', LIBRARY_VERSION = '0.1.0';
+export const DEFAULT_SCHEME = 'wss';
+export const DEFAULT_STREAMS = 2;
+export const DEFAULT_CC = 'bbr';
+export const DEFAULT_DURATION = 5000;
+
+export const SUPPORTED_CC_ALGORITHMS = ['bbr', 'cubic'];
+
+export const DEFAULT_LB_URL = 'https://locate.measurementlab.net/v2/nearest/';
+export const LB_RESOURCE_PATH = 'msak/throughput1';
+
+export const DOWNLOAD_PATH = '/throughput/v1/download';
+export const UPLOAD_PATH = '/throughput/v1/upload';

--- a/src/download.js
+++ b/src/download.js
@@ -1,10 +1,8 @@
-const workerMain = function (server) {
+const workerMain = function (ev) {
 
     // Establish WebSocket connection to the URL passed by the caller.
-    const url = new URL(server);
-    url.searchParams.set('streams', ev.data.config.streams);
-    url.searchParams.set('duration', ev.data.config.duration);
-    
+    const url = new URL(ev.data);
+
     console.log("Connecting to " + url);
     const sock = new WebSocket(url, 'net.measurementlab.throughput.v1');
     console.log("Connection established");

--- a/src/download.js
+++ b/src/download.js
@@ -1,23 +1,36 @@
-const workerMain = function(ev) {
-  const url = new URL(ev.data['///throughput/v1/download']);
+const workerMain = function (server) {
 
-  url.search += '&streams=1';
-  url.search += '&duration=5000'
-  console.log(url.search);
-  const sock = new WebSocket(url, 'net.measurementlab.throughput.v1');
+    // Establish WebSocket connection to the URL passed by the caller.
+    const url = new URL(server);
+    url.searchParams.set('streams', ev.data.config.streams);
+    url.searchParams.set('duration', ev.data.config.duration);
+    
+    console.log("Connecting to " + url);
+    const sock = new WebSocket(url, 'net.measurementlab.throughput.v1');
+    console.log("Connection established");
 
-  let now;
-  if (typeof performance !== 'undefined' &&
-      typeof performance.now === 'function') {
-    now = () => performance.now();
-  } else {
-    now = () => Date.now();
-  }
-  downloadTest(sock, postMessage, now);
+    // Define now() as either performance.now() or Date.now(). This allows to
+    // support browsers that do not support performance.now() (e.g. IE11).
+    let now;
+    if (typeof performance !== 'undefined' &&
+        typeof performance.now === 'function') {
+        now = () => performance.now();
+    } else {
+        now = () => Date.now();
+    }
+    downloadTest(sock, now);
 };
 
-const downloadTest = function(sock, postMessage, now) {
+const downloadTest = function(sock, now) {
+
+    console.log("start downloadTest");
+    let start;
+    let previous;
+    let bytesReceived;
+    let bytesSent;
+
     sock.onclose = function() {
+        console.log("onclose");
         postMessage({
             MsgType: 'close',
         });
@@ -30,14 +43,11 @@ const downloadTest = function(sock, postMessage, now) {
         });
     };
 
-    let start;
-    let previous;
-    let bytesReceived;
-
     sock.onopen = function() {
         start = now();
         previous = start;
         bytesReceived = 0;
+        bytesSent = 0;
 
         postMessage({
             MsgType: 'start',
@@ -58,12 +68,14 @@ const downloadTest = function(sock, postMessage, now) {
             const measurement = {
                 Application: {
                     BytesReceived: bytesReceived,
-                    BytesSent: 0, // TODO
+                    BytesSent: bytesSent, // TODO
                 },
                 ElapsedTime: (t - start) * 1000,
             };
 
-            sock.send(JSON.stringify(measurement));
+            const measurementStr = JSON.stringify(measurement);
+            sock.send(measurementStr);
+            bytesSent += measurementStr.length;
 
             postMessage({
                 MsgType: 'measurement',

--- a/src/locate.js
+++ b/src/locate.js
@@ -1,14 +1,13 @@
-const staticMetadata = {
-    'client_library_name': 'msak-js',
-    'client_library_version': '0.0.1',
-};
+import { DEFAULT_LB_URL as DEFAULT_LOCATE_BASE_URL, LB_RESOURCE_PATH, LIBRARY_NAME, LIBRARY_VERSION } from "./consts";
 
 /**
  * discoverServerURLs contacts a web service (likely the Measurement Lab
  * locate service, but not necessarily) and gets URLs with access tokens in
  * them for the client. 
  *
- * @param {Object} config - An associative array of configuration options.
+ * @param {string} clientName - The name of the client.
+ * @param {string} clientVersion - The client version.
+ * @param {string} [lbBaseURL] - The base URL of the load balancer. (optional)
  *
  * It uses the callback functions `error`, `serverDiscovery`, and
  * `serverChosen`.
@@ -16,20 +15,26 @@ const staticMetadata = {
  * @name discoverServerURLs
  * @public
  */
-export async function discoverServerURLs(config, userCallbacks) {
-    let protocol = "wss";
+export async function discoverServerURLs(clientName, clientVersion, lbBaseURL) {
+    if (!lbBaseURL) {
+        lbBaseURL = DEFAULT_LOCATE_BASE_URL
+    }
+    const lbURL = new URL(lbBaseURL + LB_RESOURCE_PATH);
+    
+    // Pass client/library name and versions to the load balancer in the
+    // querystring.
+    const params = new URLSearchParams();
+    params.set('client_name', clientName);
+    params.set('client_version', clientVersion);
+    params.set("client_library_name", LIBRARY_NAME);
+    params.set('client_library_version', LIBRARY_VERSION)
 
-    config.metadata = Object.assign({}, config.metadata);
-    config.metadata = Object.assign(config.metadata, staticMetadata);
-
-    const metadata = new URLSearchParams(config.metadata);
-
-    const lbURL = (config && ("loadbalancer" in config)) ? config.loadbalancer : new URL("https://locate.measurementlab.net/v2/nearest/msak/throughput1");
-    lbURL.search = metadata;
+    lbURL.search = params.toString();
 
     const response = await fetch(lbURL).catch((err) => {
         throw new Error(err);
     });
+
     const js = await response.json();
     if (!("results" in js)) {
         console.log(`Could not understand response from ${lbURL}: ${js}`);
@@ -43,11 +48,8 @@ export async function discoverServerURLs(config, userCallbacks) {
     // in cases where we have a single pod in a metro, that pod is used to
     // run the measurement. When there are multiple pods in the same metro,
     // they are randomized by the load balancer already.
-    const choice = js.results[0];
-    userCallbacks.serverChosen(choice);
+    
+    console.log(js.results);
 
-    return {
-        "///throughput/v1/download": choice.urls[protocol + ":///throughput/v1/download"],
-        "///throughput/v1/upload": choice.urls[protocol + ":///throughput/v1/upload"],
-    };
+    return js.results;
 }

--- a/src/msak.js
+++ b/src/msak.js
@@ -1,5 +1,4 @@
 import { discoverServerURLs } from "./locate";
-import { defaultErrCallback } from "./callbacks";
 import * as consts from "./consts";
 
 /**
@@ -46,6 +45,10 @@ export class Client {
         this.callbacks = {};
     }
 
+    //
+    // Setters
+    //
+
     /**
      * @param {boolean} value - Whether to print debug messages to the console.
      */
@@ -84,6 +87,10 @@ export class Client {
         }
         this.protocol = value;
     }
+
+    //
+    // Private methods
+    //
 
     /**
      * 
@@ -142,6 +149,8 @@ export class Client {
             "///throughput/v1/upload": uploadURL.toString()
         };
     }
+
+    // Public methods
 
     /**
      * Retrieves the next download/upload URL pair from the Locate service. On
@@ -218,7 +227,7 @@ export class Client {
     async runWorker(workerfile, serverURL) {
         const worker = new Worker(workerfile);
 
-        const workerTimeout = setTimeout(() => worker.terminate(), 10000);
+        setTimeout(() => worker.terminate(), this._duration);
         worker.onmessage = (ev) => this.#handleWorkerEvent(ev);
         worker.postMessage(serverURL.toString());
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "include": ["src/**/*"],
+    "compilerOptions": {
+      // Tells TypeScript to read JS files, as
+      // normally they are ignored as source files
+      "allowJs": true,
+      // Generate d.ts files
+      "declaration": true,
+      // This compiler run should
+      // only output d.ts files
+      "emitDeclarationOnly": true,
+      // Types should go into this directory.
+      // Removing this would place the .d.ts files
+      // next to the .js files
+      "outDir": "dist",
+      // go to js file when using IDE functions like
+      // "Go to Definition" in VSCode
+      "declarationMap": true
+    }
+  }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,13 +6,14 @@ const config = {
   entry: './src/msak.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'bundle.js',
+    filename: 'msak.js',
     library: {
       type: 'umd',
       name: 'msak',
     },
     globalObject: 'this',
   },
+  devtool: 'source-map',
   module: {
     rules: [
       {
@@ -23,7 +24,7 @@ const config = {
     ]
   },
   plugins: [
-    new CleanWebpackPlugin()
+    new CleanWebpackPlugin(),
   ]
 };
 


### PR DESCRIPTION
This PR:

- Turns the msak client into a ES6 `class`
- Moves all constants to `consts.js`
- Moves callbacks-related code to `callbacks.js`
- Adds a `tsconfig.json` to enable type checking based on JSDoc for JavaScript files (to make it work in vscode, set `js/ts.implicitProjectConfig.checkJs` and `js/ts.implicitProjectConfig.strictFunctionTypes` in your settings)
- Adds setters for protocol options that do sanity checks
- Better separates concerns:
  - The worker does not need to add querystring parameters to the URL anymore since the URL passed by `Client` contains them already
  - Code in locate.js does not need to know about protocol-specific metadata

This is an intermediate PR meant to get feedback on the code structure and approach. I have not added the callbacks nor the goodput/throughput calculation, the event handler just prints events coming from the worker(s) to the console to check that everything works so far.

This should be all it's needed to build and test it:
```
nvm use stable
npm install
npx webpack --mode=development # this generates a UMD module in dist/msak.js
python3 -m http.server
```
Open http://localhost:8000 in a browser, check the JS console.