### PR TITLE
Embed workers and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # msak-js
-JavaScript client for MSAK's multi-stream throughput measurement protocol
+JavaScript client library for the [MSAK](https://github.com/m-lab/msak) multi-stream throughput measurement protocol.
+
+## How to build
+```bash
+# Clone the repository
+git clone https://github.com/m-lab/msak-js
+cd msak-js
+
+# Install dependencies
+$ npm install
+
+# Run webpack
+$ npx webpack
+```
+
+This will build the library and write the resulting UMD module in `dist/msak.js`
+
+## How to use
+Include `msak.js` in your HTML page:
+```html
+ <script src="msak.js" type="text/javascript"></script>
+```
+
+Create a new `msak.Client`, specifying your client name and version and providing your custom callbacks:
+
+```js
+let client = new msak.Client(CLIENTNAME, CLIENTVERSION, {
+    onDownloadResult: (result) => {
+        console.log(result);
+    },
+    onDownloadMeasurement: (measurement) => {
+        console.log(measurement);
+    },
+    onUploadResult: (result) => {
+        console.log(result);
+    },
+    onUploadMeasurement: (measurement) => {
+        console.log(measurement);
+    },
+    onError: (err) => {
+        console.log("error: " + err);
+    }
+});
+```
+
+For a complete example, see [index.html](index.html).

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,13 @@ const config = {
         test: /\.js$/,
         use: 'babel-loader',
         exclude: /node_modules/
-      }
+      },
+      {
+        test: /(download|upload)\.js$/,
+        use: 'babel-loader',
+        exclude: /(node_modules)/,
+        type: "asset/inline",
+      },
     ]
   },
   plugins: [


### PR DESCRIPTION
This PR changes the webpack configuration to inline worker files and updates the README.

Inlining workers allows to run the example index.html without setting up a local HTTP server, since the browser would otherwise prevent their execution from a local folder.

Closes #3.