### PR TITLE
Implement byte limits for download and upload

### DIFF
--- a/examples/chart.html
+++ b/examples/chart.html
@@ -21,6 +21,9 @@
                 <option value="cubic">cubic</option>
                 <option value="bbr" selected>bbr</option>
             </select>
+        </label><br>
+        <label>Byte limit:
+            <input type="text" id="bytes" value="">
         </label><br><br>
         <button id="start">Start</button>
     </div><br>
@@ -110,6 +113,11 @@
             m.cc = document.getElementById("cc").value;
             m.duration = document.getElementById("duration").value;
             m.streams = document.getElementById("streams").value;
+
+            const byteLimit = document.getElementById("bytes").value;
+            if (byteLimit > 0) {
+                m.bytes = byteLimit;
+            }
             console.log("starting with cc " + m.cc + " duration " + m.duration + " streams " + m.streams);
             m.start();
         }

--- a/examples/index.html
+++ b/examples/index.html
@@ -36,6 +36,8 @@
         m.cc = 'bbr';
         m.duration = 5000;
         m.streams = 2;
+        // Uncomment to enable byte limit.
+        // m.bytes = 100000;
         m.start();
     </script>
 </body>

--- a/src/msak.js
+++ b/src/msak.js
@@ -111,7 +111,7 @@ export class Client {
      * @param {number} value - The maximum number of bytes to send/receive.
      */
     set bytes(value) {
-        if (value <= 0) {
+        if (value < 0) {
             throw new Error("bytes must be greater than 0");
         }
         this.#byteLimit = value;

--- a/src/msak.js
+++ b/src/msak.js
@@ -12,6 +12,7 @@ export class Client {
     #protocol = consts.DEFAULT_PROTOCOL;
     #streams = consts.DEFAULT_STREAMS;
     #duration = consts.DEFAULT_DURATION;
+    #byteLimit = 0;
 
     #server = "";
     #startTime = undefined;
@@ -106,6 +107,16 @@ export class Client {
         this.#duration = value;
     }
 
+    /**
+     * @param {number} value - The maximum number of bytes to send/receive.
+     */
+    set bytes(value) {
+        if (value <= 0) {
+            throw new Error("bytes must be greater than 0");
+        }
+        this.#byteLimit = value;
+    }
+
     //
     // Private methods
     //
@@ -140,6 +151,7 @@ export class Client {
         sp.set("streams", this.#streams.toString());
         sp.set("cc", this.#cc);
         sp.set('duration', this.#duration.toString());
+        sp.set("bytes", this.#byteLimit.toString());
 
         // Set additional custom metadata.
         if (this.metadata) {
@@ -190,14 +202,17 @@ export class Client {
 
         if (message.type == 'measurement') {
             let measurement;
+            let source = "";
             switch (testType) {
                 case 'download':
                     if (message.client) {
+                        source = 'client';
                         measurement = message.client;
                     }
                     break;
                 case 'upload':
                     if (message.server) {
+                        source = 'server';
                         measurement = JSON.parse(message.server);
                     }
                     break;
@@ -206,7 +221,9 @@ export class Client {
             }
 
             if (measurement) {
-                this.#bytesReceivedPerStream[id] = measurement.Application.BytesReceived;
+                console.log("measurement");
+                this.#bytesReceivedPerStream[id] = measurement.Application.BytesReceived || 0;
+                this.#bytesSentPerStream[id] = measurement.Application.BytesSent || 0;
 
                 const elapsed = (performance.now() - this.#startTime) / 1000;
                 const goodput = this.#bytesReceivedPerStream[id] / measurement.ElapsedTime * 8;
@@ -215,8 +232,8 @@ export class Client {
 
                 this.#debug('stream #' + id + ' elapsed ' + (measurement.ElapsedTime / 1e6).toFixed(2) + 's' +
                     ' application r/w: ' +
-                    measurement.Application.BytesReceived + '/' +
-                    measurement.Application.BytesSent +
+                    this.#bytesReceivedPerStream[id] + '/' +
+                    this.#bytesSentPerStream[id] + ' bytes' +
                     ' stream goodput: ' + goodput.toFixed(2) + ' Mb/s' +
                     ' aggr goodput: ' + aggregateGoodput.toFixed(2) + ' Mb/s');
 
@@ -225,7 +242,7 @@ export class Client {
                     stream: id,
                     goodput: goodput,
                     measurement: measurement,
-                    source: 'client',
+                    source: source,
                 });
 
                 this.callbacks.onResult({
@@ -372,7 +389,10 @@ export class Client {
         worker.onmessage = (ev) => {
             this.#handleWorkerEvent(ev, testType, streamID, worker);
         };
-        worker.postMessage(serverURL.toString());
+        worker.postMessage({
+            url: serverURL.toString(),
+            bytes: this.#byteLimit
+        });
 
         return workerPromise;
     }

--- a/src/msak.js
+++ b/src/msak.js
@@ -221,7 +221,6 @@ export class Client {
             }
 
             if (measurement) {
-                console.log("measurement");
                 this.#bytesReceivedPerStream[id] = measurement.Application.BytesReceived || 0;
                 this.#bytesSentPerStream[id] = measurement.Application.BytesSent || 0;
 

--- a/src/upload.js
+++ b/src/upload.js
@@ -138,7 +138,6 @@ const uploadTest = function (sock, byteLimit, now) {
         // Message size is doubled after the first 16 messages, and subsequently
         // every 8, up to maxMessageSize.
         const origSize = data.length;
-        console.log("origSize " + origSize);
 
         if (origSize < MAX_MESSAGE_SIZE &&
             origSize < bytesSent / SCALING_FRACTION) {
@@ -180,7 +179,6 @@ const uploadTest = function (sock, byteLimit, now) {
         // Check if the next payload size will push the total number of bytes over the limit.
         const excess = bytesSent + msgSize - byteLimit;
         if (byteLimit > 0 && excess > 0) {
-            console.log("Excess " + excess + " bytes");
             msgSize -= excess;
         }
         return msgSize;

--- a/src/upload.js
+++ b/src/upload.js
@@ -139,8 +139,7 @@ const uploadTest = function (sock, byteLimit, now) {
         // every 8, up to maxMessageSize.
         const origSize = data.length;
 
-        if (origSize < MAX_MESSAGE_SIZE &&
-            origSize > bytesSent / SCALING_FRACTION) {
+        if (origSize >= MAX_MESSAGE_SIZE || origSize > bytesSent / SCALING_FRACTION) {
             size = scaleMessage(origSize);
         } else {
             console.log("Increasing message size to " + origSize * 2 + " bytes");

--- a/src/upload.js
+++ b/src/upload.js
@@ -5,7 +5,9 @@ const SCALING_FRACTION = 16;
 const workerMain = function (ev) {
 
     // Establish WebSocket connection to the URL passed by the caller.
-    const url = new URL(ev.data);
+    const url = new URL(ev.data.url);
+    const byteLimit = ev.data.bytes;
+
     console.log("Connecting to " + url);
     const sock = new WebSocket(url, 'net.measurementlab.throughput.v1');
     console.log("Connection established");
@@ -20,10 +22,10 @@ const workerMain = function (ev) {
     } else {
         now = () => Date.now();
     }
-    uploadTest(sock, now);
+    uploadTest(sock, byteLimit, now);
 };
 
-const uploadTest = function (sock, now) {
+const uploadTest = function (sock, byteLimit, now) {
     let closed = false;
     let bytesReceived;
     let bytesSent;
@@ -117,11 +119,12 @@ const uploadTest = function (sock, now) {
             return;
         }
 
-        // Message size is doubled after the first 16 messages, and subsequently
-        // every 8, up to maxMessageSize.
-        if (data.length < MAX_MESSAGE_SIZE &&
-            data.length < (bytesSent - sock.bufferedAmount) / SCALING_FRACTION) {
-            data = new Uint8Array(data.length * 2);
+        // Check if we are over the limit and, if so, stop the uploader loop.
+        // The server is going to close the connection after the byte limit has
+        // been reached or the duration timeout has expired. Meanwhile, the client
+        // keeps running and handling WebSocket events.
+        if (bytesSent >= byteLimit) {
+            return;
         }
 
         // We keep 7 messages in the send buffer, so there is always some more
@@ -130,6 +133,22 @@ const uploadTest = function (sock, now) {
         if (sock.bufferedAmount < desiredBuffer) {
             sock.send(data);
             bytesSent += data.length;
+        }
+
+        // Message size is doubled after the first 16 messages, and subsequently
+        // every 8, up to maxMessageSize.
+        const origSize = data.length;
+        console.log("origSize " + origSize);
+
+        if (origSize < MAX_MESSAGE_SIZE &&
+            origSize < bytesSent / SCALING_FRACTION) {
+            size = scaleMessage(origSize)
+        } else {
+            size = scaleMessage(origSize * 2);
+        }
+
+        if (size != origSize) {
+            data = new Uint8Array(size);
         }
 
         if (t >= previous + MEASUREMENT_INTERVAL) {
@@ -155,6 +174,16 @@ const uploadTest = function (sock, now) {
 
         // Loop the uploader function in a way that respects the JS event handler.
         setTimeout(() => uploader(data, start, end, previous), 0);
+    }
+
+    function scaleMessage(msgSize) {
+        // Check if the next payload size will push the total number of bytes over the limit.
+        const excess = bytesSent + msgSize - byteLimit;
+        if (byteLimit > 0 && excess > 0) {
+            console.log("Excess " + excess + " bytes");
+            msgSize -= excess;
+        }
+        return msgSize;
     }
 };
 

--- a/src/upload.js
+++ b/src/upload.js
@@ -6,7 +6,7 @@ const workerMain = function (ev) {
 
     // Establish WebSocket connection to the URL passed by the caller.
     const url = new URL(ev.data.url);
-    const byteLimit = ev.data.bytes;
+    const byteLimit = ev.data.bytes || 0;
 
     console.log("Connecting to " + url);
     const sock = new WebSocket(url, 'net.measurementlab.throughput.v1');
@@ -123,7 +123,7 @@ const uploadTest = function (sock, byteLimit, now) {
         // The server is going to close the connection after the byte limit has
         // been reached or the duration timeout has expired. Meanwhile, the client
         // keeps running and handling WebSocket events.
-        if (bytesSent >= byteLimit) {
+        if (byteLimit > 0 && bytesSent >= byteLimit) {
             return;
         }
 
@@ -140,9 +140,10 @@ const uploadTest = function (sock, byteLimit, now) {
         const origSize = data.length;
 
         if (origSize < MAX_MESSAGE_SIZE &&
-            origSize < bytesSent / SCALING_FRACTION) {
-            size = scaleMessage(origSize)
+            origSize > bytesSent / SCALING_FRACTION) {
+            size = scaleMessage(origSize);
         } else {
+            console.log("increasing to " + origSize * 2);
             size = scaleMessage(origSize * 2);
         }
 

--- a/src/upload.js
+++ b/src/upload.js
@@ -143,7 +143,7 @@ const uploadTest = function (sock, byteLimit, now) {
             origSize > bytesSent / SCALING_FRACTION) {
             size = scaleMessage(origSize);
         } else {
-            console.log("increasing to " + origSize * 2);
+            console.log("Increasing message size to " + origSize * 2 + " bytes");
             size = scaleMessage(origSize * 2);
         }
 


### PR DESCRIPTION
This PR implements byte limits in both directions.

- For downloads, the limit is enforced by the server, we just make sure that one last measurement is posted upstream to the main thread
- For uploads, we stop queuing new messages after `bytesSent >= byteLimit`. The code structure mimics the equivalent [Go version](https://github.com/m-lab/msak/blob/main/pkg/throughput1/protocol.go#L248) a bit more now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak-js/14)
<!-- Reviewable:end -->

Closes #5 