### PR TITLE
Add onStart callback

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -8,18 +8,28 @@
 </head>
 
 <body>
+    <div id="server-dl"></div>
     <div id="goodput-dl"></div>
+    <div id="server-ul"></div>
     <div id="goodput-ul"></div>
 
     <script src="../dist/msak.js" type="text/javascript"></script>
     <script>
         m = new msak.Client("msakjs-example", "0.1.0", {
+            onDownloadStart: (server) => {
+                document.getElementById("server-dl").innerHTML = "Server: " +
+                    `${server.machine} (${server.location.city}, ${server.location.country})`;
+            },
             onDownloadResult: (result) => {
                 document.getElementById("goodput-dl").innerHTML = "Download: " +
                     result.goodput.toFixed(2) + " Mb/s";
             },
             onDownloadMeasurement: (measurement) => {
                 console.log(measurement);
+            },
+            onUploadStart: (server) => {
+                document.getElementById("server-ul").innerHTML = "Server: " +
+                `${server.machine} (${server.location.city}, ${server.location.country})`;
             },
             onUploadResult: (result) => {
                 document.getElementById("goodput-ul").innerHTML = "Upload: " +

--- a/src/msak.js
+++ b/src/msak.js
@@ -342,6 +342,7 @@ export class Client {
         } else {
             serverURLs = await this.#nextURLsFromLocate();
         }
+
         await this.download(serverURLs['//' + consts.DOWNLOAD_PATH]);
         await this.upload(serverURLs['//' + consts.UPLOAD_PATH]);
     }
@@ -357,6 +358,7 @@ export class Client {
         // Set callbacks.
         this.callbacks = {
             ...this.callbacks,
+            onStart: cb('onDownloadStart', this.callbacks),
             onResult: cb('onDownloadResult', this.callbacks),
             onMeasurement: cb('onDownloadMeasurement', this.callbacks),
             onError: cb('onError', this.callbacks, defaultErrCallback),
@@ -383,6 +385,7 @@ export class Client {
         // Set callbacks.
         this.callbacks = {
             ...this.callbacks,
+            onStart: cb('onUploadStart', this.callbacks),
             onResult: cb('onUploadResult', this.callbacks),
             onMeasurement: cb('onUploadMeasurement', this.callbacks),
             onError: cb('onError', this.callbacks, defaultErrCallback),
@@ -391,6 +394,7 @@ export class Client {
         // Reset byte counters and start time.
         this.#bytesReceivedPerStream = [];
         this.#bytesSentPerStream = [];
+        this.#lastTCPInfoPerStream = [];
         this.#startTime = undefined;
 
         let workerPromises = [];


### PR DESCRIPTION
Add an `onStart(server)` callback to tell the user what server was used to run the stream. If the server comes from Locate, `server.location` and `server.machine` are also available.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak-js/18)
<!-- Reviewable:end -->
