### PR TITLE
Fix minRTT calculation

### DIFF
--- a/src/msak.js
+++ b/src/msak.js
@@ -293,7 +293,7 @@ export class Client {
                     elapsed: elapsed,
                     goodput: aggregateGoodput,
                     retransmission: avgRetrans,
-                    minRTT: Math.min(this.#lastTCPInfoPerStream.map(x => x.MinRTT)),
+                    minRTT: Math.min(...this.#lastTCPInfoPerStream.map(x => x.MinRTT)),
                 });
             }
         }


### PR DESCRIPTION
`Math.min()` does not appreciate arrays as parameters and returns `NaN`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak-js/20)
<!-- Reviewable:end -->
