### PR TITLE
fix: move safety timeout to connect event and use configured upload duration

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -7,6 +7,7 @@ const workerMain = function (ev) {
     // Establish WebSocket connection to the URL passed by the caller.
     const url = new URL(ev.data.url);
     const byteLimit = ev.data.bytes || 0;
+    const duration = ev.data.duration || 10000;
 
     console.log("Connecting to " + url);
     const sock = new WebSocket(url, 'net.measurementlab.throughput.v1');
@@ -22,10 +23,10 @@ const workerMain = function (ev) {
     } else {
         now = () => Date.now();
     }
-    uploadTest(sock, byteLimit, now);
+    uploadTest(sock, byteLimit, duration, now);
 };
 
-const uploadTest = function (sock, byteLimit, now) {
+const uploadTest = function (sock, byteLimit, duration, now) {
     let closed = false;
     let bytesReceived;
     let bytesSent;
@@ -66,7 +67,6 @@ const uploadTest = function (sock, byteLimit, now) {
         const initialMessageSize = 8192; /* (1<<13) = 8kBytes */
         const data = new Uint8Array(initialMessageSize);
         const start = now(); // ms since epoch
-        const duration = 10000; // ms
         const end = start + duration; // ms since epoch
 
         postMessage({


### PR DESCRIPTION
- Move the safety `setTimeout` from `runWorker()` to the `connect` event in `#handleWorkerEvent`, so WS+TLS handshake time does not eat into the test duration
- Pass configured `duration` to the upload worker via `postMessage` instead of hardcoding `10000ms` in `upload.js`
- Also includes the minRTT null-safety fix for streams without TCPInfo

I believe this is the main culprit for the well-known termination bug that causes MSAK's `ElapsedTime` distribution shape to be different from ndt7's:

<img width="938" height="378" alt="image" src="https://github.com/user-attachments/assets/6d3e7911-34e8-436e-9982-fa50d9c6aee3" />


The client sets a timeout of `expectedDuration + 1s` _for the whole of the download worker execution which includes the WS connection's setup time. The practical result is that tests from clients with higher RTTs will see test runtimes < `expectedDuration` due to the client terminating the test before the server.

The proposed solution to that is to have two separate timeouts:

- one for the WS connection setup (10s)
- one for the test duration, starting when the WebSocket connection is complete (`duration+1s` since we prefer the server to close the connection first)

When the `onConnect` event fires, the WS connection setup timeout is stopped.

Why is this not a problem for ndt7? Well... I think it might be. The worker timeout in ndt7 [is set to 12s](https://github.com/m-lab/ndt7-js/blob/main/src/ndt7.js#L206), so I expect to see tests shorter than 10s on RTTs > 667ms. More specifically:

- 3 RTTs for handshake (TCP + TLS 1.3 + WS upgrade)
- ndt7: 12s - 10s = 2s margin → starts at ~667ms RTT                                 
- MSAK (before this fix): duration + 1s margin → starts at ~333ms RTT

So, the ndt7 client has the same issue - just less noticeable due to two seconds of margin instead of one. In fact, the same effect is visible in the ndt7 ElapsedTime PDF graph, on the left side of 10s.

cc @mattmathis you might find this interesting! :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak-js/23)
<!-- Reviewable:end -->
