### PR TITLE
fix(locate): throw descriptive errors instead of returning invalid data

### DIFF
--- a/src/locate.js
+++ b/src/locate.js
@@ -31,14 +31,20 @@ export async function discoverServerURLs(clientName, clientVersion, lbBaseURL) {
 
     lbURL.search = params.toString();
 
-    const response = await fetch(lbURL).catch((err) => {
-        throw new Error(err);
-    });
+    let response;
+    try {
+        response = await fetch(lbURL);
+    } catch (err) {
+        throw new Error(`Locate fetch failed (${lbURL}): ${err.message}`);
+    }
+
+    if (!response.ok) {
+        throw new Error(`Locate returned HTTP ${response.status} (${lbURL})`);
+    }
 
     const js = await response.json();
-    if (!("results" in js)) {
-        console.log(`Could not understand response from ${lbURL}: ${js}`);
-        return {};
+    if (!("results" in js) || !Array.isArray(js.results) || js.results.length === 0) {
+        throw new Error(`Locate returned no results (${lbURL})`);
     }
 
     // TODO: do not discard unused results. If the first server is unavailable
@@ -48,8 +54,6 @@ export async function discoverServerURLs(clientName, clientVersion, lbBaseURL) {
     // in cases where we have a single pod in a metro, that pod is used to
     // run the measurement. When there are multiple pods in the same metro,
     // they are randomized by the load balancer already.
-
-    console.log(js.results);
 
     return js.results;
 }

--- a/src/msak.js
+++ b/src/msak.js
@@ -354,12 +354,9 @@ export class Client {
 
         // If this is the first call or the cache is empty, query the Locate service.
         if (this.#locateCache.length == 0) {
-            const results = await discoverServerURLs(this.clientName, this.clientVersion)
-            this.#locateCache = results;
-            return getFromCache();
-        } else {
-            return getFromCache();
+            this.#locateCache = await discoverServerURLs(this.clientName, this.clientVersion);
         }
+        return getFromCache();
     }
 
     // Public methods


### PR DESCRIPTION
## Summary

- `discoverServerURLs()` returned `{}` (plain object) when the locate API response had no `"results"` key, causing `TypeError: x(...).shift is not a function` when `msak.js` called `.shift()` on the non-array (~220 events on Sentry in the last 24h)
- Now throws descriptive errors for all three failure modes — network failure, HTTP error, empty results — each including the locate URL so issues are diagnosable via Sentry
- Simplified `#nextServerFromLocate()` since `discoverServerURLs()` now throws on all failures instead of returning bad data

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak-js/24)
<!-- Reviewable:end -->
