### PR TITLE
fix(workers): include server hostname in WebSocket error messages

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -18,10 +18,10 @@ const workerMain = function (ev) {
     } else {
         now = () => Date.now();
     }
-    downloadTest(sock, byteLimit, now);
+    downloadTest(sock, url.host, byteLimit, now);
 };
 
-const downloadTest = function(sock, byteLimit, now) {
+const downloadTest = function(sock, host, byteLimit, now) {
 
     let start;
     let previous;
@@ -47,10 +47,10 @@ const downloadTest = function(sock, byteLimit, now) {
         });
     };
 
-    sock.onerror = function(ev) {
+    sock.onerror = function() {
         postMessage({
             type: 'error',
-            error: ev.type,
+            error: 'WebSocket error (' + host + ')',
         });
     };
 

--- a/src/upload.js
+++ b/src/upload.js
@@ -23,10 +23,10 @@ const workerMain = function (ev) {
     } else {
         now = () => Date.now();
     }
-    uploadTest(sock, byteLimit, duration, now);
+    uploadTest(sock, url.host, byteLimit, duration, now);
 };
 
-const uploadTest = function (sock, byteLimit, duration, now) {
+const uploadTest = function (sock, host, byteLimit, duration, now) {
     let closed = false;
     let bytesReceived;
     let bytesSent;
@@ -40,10 +40,10 @@ const uploadTest = function (sock, byteLimit, duration, now) {
         }
     };
 
-    sock.onerror = function (ev) {
+    sock.onerror = function () {
         postMessage({
             type: 'error',
-            error: ev.type,
+            error: 'WebSocket error (' + host + ')',
         });
     };
 


### PR DESCRIPTION
## Summary

- WebSocket `onerror` handlers in download/upload workers posted `ev.type` as the error message, which is always the literal string `"error"` (DOM Event spec) — making errors undiagnosable in Sentry (~103 events showing as `Error: error` with no context)
- Now includes the server hostname: `WebSocket error ($URL)` so failed connections can be traced to specific servers

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak-js/26)
<!-- Reviewable:end -->
